### PR TITLE
styling components on homepage

### DIFF
--- a/src/components/KeywordRadioBtnGroup/KeywordRadioBtnGroup.module.scss
+++ b/src/components/KeywordRadioBtnGroup/KeywordRadioBtnGroup.module.scss
@@ -10,7 +10,7 @@ fieldset.radioGroupWrapper {
 
   .radioWrapper {
     display: flex;
-    margin-right: 1.8rem;
+    margin-right: 18px;
 
     &:last-of-type {
       margin-right: 0;
@@ -18,9 +18,9 @@ fieldset.radioGroupWrapper {
 
     input[type="radio"] {
       position: relative;
-      height: 1.5rem;
-      width: 1.5rem;
-      margin-right: 0.5rem;
+      height: 15px;
+      width: 15px;
+      margin-right: 5px;
       align-self: center;
       accent-color: $color-yellow-base;
 
@@ -49,8 +49,8 @@ fieldset.radioGroupWrapper {
 
     .radioWrapper {
       input[type="radio"] {
-        height: 1.2rem;
-        width: 1.2rem;
+        height: 12px;
+        width: 12px;
       }
     }
   }

--- a/src/components/KeywordRadioBtnGroup/KeywordRadioBtnGroup.module.scss
+++ b/src/components/KeywordRadioBtnGroup/KeywordRadioBtnGroup.module.scss
@@ -1,7 +1,57 @@
-.radioGroupWrapper {
+@use "../../styles/settings" as *;
+
+fieldset.radioGroupWrapper {
   display: flex;
+  position: relative;
+  top: -40px;
+  margin: 0 auto;
+  max-width: 75%;
+  border: none;
 
   .radioWrapper {
     display: flex;
+    margin-right: 1.8rem;
+
+    &:last-of-type {
+      margin-right: 0;
+    }
+
+    input[type="radio"] {
+      position: relative;
+      height: 1.5rem;
+      width: 1.5rem;
+      margin-right: 0.5rem;
+      align-self: center;
+      accent-color: $color-yellow-base;
+
+      &:first-of-type {
+        margin-left: 3px;
+      }
+      &:checked + label {
+        color: $color-yellow-base;
+      }
+    }
+
+    label {
+      color: $color-white-base;
+      font-size: var(--font-function-size);
+      font-family: $font-function;
+      font-weight: bold;
+    }
+  }
+}
+
+@media (max-width: $breakpoint) {
+  fieldset.radioGroupWrapper {
+    display: block;
+    float: left;
+    padding-left: 0px;
+
+    .radioWrapper {
+      input[type="radio"] {
+        height: 1.2rem;
+        width: 1.2rem;
+      }
+    }
   }
 }

--- a/src/components/KeywordRadioBtnGroup/KeywordRadioBtnGroup.tsx
+++ b/src/components/KeywordRadioBtnGroup/KeywordRadioBtnGroup.tsx
@@ -32,8 +32,8 @@ export function KeywordRadioBtnGroup() {
   };
 
   return (
-    <div className={styles.radioGroupWrapper}>
-      {["name", "city", "country", "any"].map((value) => (
+    <fieldset className={styles.radioGroupWrapper}>
+      {["name", "city", "country", "any keyword"].map((value) => (
         <RadioBtn
           key={value}
           value={value}
@@ -41,6 +41,6 @@ export function KeywordRadioBtnGroup() {
           selected={keyword}
         />
       ))}
-    </div>
+    </fieldset>
   );
 }

--- a/src/components/ModeToggleBtn/ModeToggleBtn.module.scss
+++ b/src/components/ModeToggleBtn/ModeToggleBtn.module.scss
@@ -1,0 +1,92 @@
+@use "../../styles/settings" as *;
+
+.toggle {
+  position: absolute;
+  right: 2rem;
+  top: 2rem;
+  font-family: $font-content;
+  font-weight: bold;
+  display: inline-block;
+  vertical-align: top;
+  margin: 0 15px 0 0;
+}
+
+.toggleInput {
+  display: none;
+
+  &:checked + .toggleButton {
+    background-color: $color-white-base;
+  }
+
+  &:checked + .toggleButton::before {
+    left: 4px;
+    content: "light";
+    background-color: $color-yellow-base;
+    color: $color-white-base;
+  }
+}
+
+.toggleButton {
+  display: inline-block;
+  position: relative;
+  height: 30px;
+  width: 90px;
+  box-sizing: border-box;
+  border-top: 2px solid gray;
+  border-left: 2px solid gray;
+  border-bottom: 2px solid black;
+  border-right: 2px solid black;
+  background-color: $color-gray-light;
+  border-radius: 5px;
+  color: $color-white-base;
+  font-size: 14px;
+  text-transform: uppercase;
+  line-height: 21px;
+  cursor: pointer;
+  transition: background-color 0.5s linear;
+
+  &::before {
+    display: inline-block;
+    height: 20px;
+    position: absolute;
+    top: 3px;
+    left: 40px;
+    padding: 0 3px;
+    background-color: $color-gray-dark;
+    border-radius: 3px;
+    content: "dark";
+    color: $color-brown-base;
+    transition: left 0.5s linear, background-color 0.5s linear,
+      color 0.5s linear;
+  }
+}
+
+@media (max-width: 510px) {
+  .toggle {
+    right: 0.5rem;
+    top: 2rem;
+  }
+
+  .toggleInput {
+    &:checked + .toggle-button::before {
+      left: 2px;
+    }
+  }
+
+  .toggleButton {
+    height: 23px;
+    width: 69px;
+    border-radius: 4px;
+    font-size: 11px;
+    line-height: 16px;
+
+    &::before {
+      height: 15px;
+      top: 2px;
+      left: 28px;
+      padding: 0 2px;
+      background-color: $color-gray-dark;
+      border-radius: 3px;
+    }
+  }
+}

--- a/src/components/ModeToggleBtn/ModeToggleBtn.module.scss
+++ b/src/components/ModeToggleBtn/ModeToggleBtn.module.scss
@@ -2,8 +2,8 @@
 
 .toggle {
   position: absolute;
-  right: 2rem;
-  top: 2rem;
+  right: 20px;
+  top: 20px;
   font-family: $font-content;
   font-weight: bold;
   display: inline-block;
@@ -39,7 +39,7 @@
   background-color: $color-gray-light;
   border-radius: 5px;
   color: $color-white-base;
-  font-size: 14px;
+  font-size: 1.4rem;
   text-transform: uppercase;
   line-height: 21px;
   cursor: pointer;
@@ -63,8 +63,8 @@
 
 @media (max-width: 510px) {
   .toggle {
-    right: 0.5rem;
-    top: 2rem;
+    right: 5px;
+    top: 20px;
   }
 
   .toggleInput {
@@ -77,7 +77,7 @@
     height: 23px;
     width: 69px;
     border-radius: 4px;
-    font-size: 11px;
+    font-size: 1.1rem;
     line-height: 16px;
 
     &::before {

--- a/src/components/ModeToggleBtn/ModeToggleBtn.tsx
+++ b/src/components/ModeToggleBtn/ModeToggleBtn.tsx
@@ -2,11 +2,11 @@ import styles from "./ModeToggleBtn.module.scss";
 
 export const ModeToggleBtn = () => {
   return (
-    <div className={styles.themeToggle}>
+    <>
       <label htmlFor="toggle" className={styles.toggle}>
         <input type="checkbox" id="toggle" className={styles.toggleInput} />
         <span className={styles.toggleButton}></span>
       </label>
-    </div>
+    </>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,9 +16,7 @@ export default function Home() {
       <main>
         <form className={styles.search}>
           <Searchbar />
-          <fieldset>
-            <KeywordRadioBtnGroup />
-          </fieldset>
+          <KeywordRadioBtnGroup />
         </form>
       </main>
     </>

--- a/src/styles/Page.module.scss
+++ b/src/styles/Page.module.scss
@@ -1,7 +1,15 @@
-@use "./settings";
+@use "./settings" as *;
 
 form.search {
   max-width: 450px;
   margin: 3rem auto 1rem;
   padding: 0 3rem;
+
+  @media (max-width: $breakpoint) {
+    &::after {
+      clear: both;
+      content: "";
+      display: table;
+    }
+  }
 }

--- a/src/styles/Page.module.scss
+++ b/src/styles/Page.module.scss
@@ -2,8 +2,8 @@
 
 form.search {
   max-width: 450px;
-  margin: 3rem auto 1rem;
-  padding: 0 3rem;
+  margin: 30px auto 10px;
+  padding: 0 30px;
 
   @media (max-width: $breakpoint) {
     &::after {


### PR DESCRIPTION
PR #2:

- index.tsx: removed fieldset tag wrapping radio buttons;
- Page.module.scss: added styles for screen widths 530px and smaller;

- KeywordRadioBtnGroup.tsx: replaced div with fieldset tag and added txt to the last label;
- KeywordRadioBtnGroup.scss: styled radio buttons and labels depending on 2 screen width ranges (>530 px & <= 530px);

- ModeToggleBtn.tsx: removed unused div tag + class;
- ModeToggleBtn.module.scss: styled dark/light theme toggle button depending on 2 screen width ranges (>530 px & <= 530px);

Typography: I'm using 2 font families (Kavoon for search engine name + theme toggle button, TImes New Roman for the rest) and 2 font sizes for each font family that change with screen width range.

Colors: I'm using 3 colors for all the text (white, custom yellow, custom brown) + 2 colors (light and dark gray) for search engine name and different backgrounds/background fallbacks. 

Background: a lighter background image for light mode and a darker for dark mode will be used



